### PR TITLE
pull request

### DIFF
--- a/mailer.py
+++ b/mailer.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import logging
 import ConfigParser
 from sendemail import sendemail
 


### PR DESCRIPTION
Hi Mark,

I set up a fork and am using a minor issue I ran into as a learning example of how to submit patches.

I hit this when I hadn't set up the email.ini file and hit the lack of logging when the except block of

```
    try:
        from_address = cfg.get('report', 'from')
    except (ConfigParser.NoSectionError, ConfigParser.NoOptionError):
        logging.error('No "from" option defined in "report" section of file "%s".\n' % options.config_file)
        return
```

fired.
