### PR TITLE
Bug 807207 - Autophone - catch bad zip files which raise IOError, r=mcot...

### DIFF
--- a/builds.py
+++ b/builds.py
@@ -608,7 +608,8 @@ class BuildCache(object):
         try:
             download_build = (force or not os.path.exists(build_path) or
                               zipfile.ZipFile(build_path).testzip() is not None)
-        except zipfile.BadZipfile:
+        except (zipfile.BadZipfile, IOError), e:
+            logger.warning('%s checking build: %s. Forcing download.' % (e, buildurl))
             download_build = True
         if download_build:
             # retrieve to temporary file then move over, so we don't end


### PR DESCRIPTION
While testing if Bug 1133580 fixed this issue, I edited a build.apk to force it to fail to install and found a different error where a bad zip file can actually cause an IOError instead of just a zipfile.BadZipfile. This catches and logs the issue and forces a download.
