### PR TITLE
Bug 1172585 - s3.upload() on Win 7 results in IOError

### DIFF
--- a/s3.py
+++ b/s3.py
@@ -86,7 +86,7 @@ class S3Bucket(object):
                 tf.seek(0)
                 key.set_metadata('Content-Encoding', 'gzip')
                 logger.debug('Setting key contents from: %s' % tf.name)
-                key.set_contents_from_filename(tf.name)
+                key.set_contents_from_file(tf)
 
             url = key.generate_url(expires_in=0,
                                    query_auth=False)


### PR DESCRIPTION
Cause: "Whether the name can be used to open the file a second time, while the named temporary file is still open, varies across platforms (it can be so used on Unix; it cannot on Windows NT or later)." [1]

So I propose to let `tf` close before setting the contents of the key and then delete the temp file.

[1] https://docs.python.org/2/library/tempfile.html#tempfile.NamedTemporaryFile